### PR TITLE
Made fully posix compatable and removed the reqirement on sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ PROGRAM_NAME=set-brightness
 INSTALL_PATH=/usr/local/bin
 
 install:
-	@sudo install $(PROGRAM_PATH)/$(PROGRAM_NAME) $(INSTALL_PATH)/$(PROGRAM_NAME)  
+	@install $(PROGRAM_PATH)/$(PROGRAM_NAME) $(INSTALL_PATH)/$(PROGRAM_NAME)  
 	@echo "$(PROGRAM_NAME): installed"
 
 uninstall:
-	@sudo rm -f $(INSTALL_PATH)/$(PROGRAM_NAME)
+	@rm -f $(INSTALL_PATH)/$(PROGRAM_NAME)
 	@echo "$(PROGRAM_NAME): uninstalled"

--- a/bin/set-brightness
+++ b/bin/set-brightness
@@ -59,8 +59,12 @@ is_brightness_allowed() {
 }
 
 set_brightness() {
+   if command -v sudo &> /dev/null; then
+      sudo="sudo"
+   fi
+
 	brightness=$(echo "$(get_max_brightness) * $1/100" | bc)
-	echo "$brightness" | sudo tee $SET_BRIGHTNESS_PATH > /dev/null
+	echo "$brightness" | $sudo tee $SET_BRIGHTNESS_PATH > /dev/null
 	echo "🔆 Brightness Level: ${1}%" 
 }
 

--- a/bin/set-brightness
+++ b/bin/set-brightness
@@ -49,7 +49,6 @@ is_brightness_allowed() {
 		echo "$PROGRAM_NAME: error: invalid level, must be an integer."
 		exit 1
       ;;
-      *) echo good ;;
       esac
 
 	if [ "$1" -gt 100 ]; then

--- a/bin/set-brightness
+++ b/bin/set-brightness
@@ -46,8 +46,8 @@ get_max_brightness() {
 is_brightness_allowed() {
       case $1 in
          ''|*[!0-9]*)
-		echo "$PROGRAM_NAME: error: invalid level, must be an integer."
-		exit 1
+		   echo "$PROGRAM_NAME: error: invalid level, must be an integer."
+		   exit 1
       ;;
       esac
 
@@ -59,12 +59,12 @@ is_brightness_allowed() {
 
 set_brightness() {
    if command -v sudo &> /dev/null; then
-      sudo="sudo"
+         sudo="sudo"
    fi
 
 	brightness=$(echo "$(get_max_brightness) * $1/100" | bc)
-	echo "$brightness" | $sudo tee $SET_BRIGHTNESS_PATH > /dev/null
-	echo "🔆 Brightness Level: ${1}%" 
+   echo "$brightness" | $sudo tee $SET_BRIGHTNESS_PATH > /dev/null
+   echo "🔆 Brightness Level: ${1}%" 
 }
 
 parse_cli "$1"

--- a/bin/set-brightness
+++ b/bin/set-brightness
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2020 Puru Tuladhar <ptuladhar3@gmail.com>
 # See LICENSE file.
@@ -8,8 +8,8 @@ VERSION=1.0
 MAX_BRIGHTNESS_PATH=/sys/class/backlight/intel_backlight/max_brightness
 SET_BRIGHTNESS_PATH=/sys/class/backlight/intel_backlight/brightness
 
-function parse_cli() {
-	if [[ -z $1 || "$1" == "-h" || "$1" == "--help" ]]; then
+parse_cli() {
+     if [ -z "$1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
 		echo "$PROGRAM_NAME - Adjust the display brightness from command-line for Linux (v$VERSION)"
 		echo
 		echo "USAGE: $PROGRAM_NAME [LEVEL]"
@@ -23,14 +23,14 @@ function parse_cli() {
 		echo "	set-brightness 50 - Set brightness level to 50%"
 		exit 1
 	fi
-	if [[ "$1" == "--version" ]]; then
+	if [ "$1" = "--version" ]; then
 		echo "$PROGRAM_NAME version $VERSION"
 		exit 1
 	fi
 } 
 
-function check_hardware_support() {
-	if [[ ! -f $MAX_BRIGHTNESS_PATH || ! -f $SET_BRIGHTNESS_PATH ]]; then
+check_hardware_support() {
+	if [ ! -f $MAX_BRIGHTNESS_PATH ] || [ ! -f $SET_BRIGHTNESS_PATH ] ; then
 		echo "$PROGRAM_NAME: error: hardware not supported."
 		echo
 		echo "Please raise an issue to <> and share output of following command:"
@@ -39,28 +39,32 @@ function check_hardware_support() {
 	fi
 }
 
-function get_max_brightness() {
-	cat $MAX_BRIGHTNESS_PATH
+get_max_brightness() {
+	cat "$MAX_BRIGHTNESS_PATH"
 }
 
-function is_brightness_allowed() {
-	if ! [[ $1 =~ ^[0-9]+$ ]]; then
+is_brightness_allowed() {
+      case $1 in
+         ''|*[!0-9]*)
 		echo "$PROGRAM_NAME: error: invalid level, must be an integer."
 		exit 1
-	fi
-	if [[ $1 -gt 100 ]]; then
+      ;;
+      *) echo good ;;
+      esac
+
+	if [ "$1" -gt 100 ]; then
 		echo "$PROGRAM_NAME: error: invalid level, specify a value between 0 - 100."
 		exit 1
 	fi
 }
 
-function set_brightness() {
+set_brightness() {
 	brightness=$(echo "$(get_max_brightness) * $1/100" | bc)
-	echo $brightness | sudo tee $SET_BRIGHTNESS_PATH > /dev/null
+	echo "$brightness" | sudo tee $SET_BRIGHTNESS_PATH > /dev/null
 	echo "🔆 Brightness Level: ${1}%" 
 }
 
-parse_cli $1
+parse_cli "$1"
 check_hardware_support
-is_brightness_allowed $1
-set_brightness $1
+is_brightness_allowed "$1"
+set_brightness "$1"


### PR DESCRIPTION
Now set-brightness should run on any POSIX compliant sh - not just bash. and allow for use when sudo is not installed.